### PR TITLE
マージ時に不必要な差分データを取り込んでいたので削除した

### DIFF
--- a/second-edition/src/ch09-02-recoverable-errors-with-result.md
+++ b/second-edition/src/ch09-02-recoverable-errors-with-result.md
@@ -328,48 +328,6 @@ fn main() {
 <!-- <span class="filename">Filename: src/main.rs</span> -->
 
 <span class="filename">ファイル名: src/main.rs</span>
-=======
-<span class="caption">Listing 9-5: Handling different kinds of errors in
-different ways</span>
-
-The type of the value that `File::open` returns inside the `Err` variant is
-`io::Error`, which is a struct provided by the standard library. This struct
-has a method `kind` that we can call to get an `io::ErrorKind` value. The enum
-`io::ErrorKind` is provided by the standard library and has variants
-representing the different kinds of errors that might result from an `io`
-operation. The variant we want to use is `ErrorKind::NotFound`, which indicates
-the file we’re trying to open doesn’t exist yet.
-
-The condition `if error.kind() == ErrorKind::NotFound` is called a *match
-guard*: it’s an extra condition on a `match` arm that further refines the arm’s
-pattern. This condition must be true for that arm’s code to be run; otherwise,
-the pattern matching will move on to consider the next arm in the `match`. The
-`ref` in the pattern is needed so `error` is not moved into the guard condition
-but is merely referenced by it. The reason you use `ref` to create a reference
-in a pattern instead of `&` will be covered in detail in Chapter 18. In short,
-in the context of a pattern, `&` matches a reference and gives you its value,
-but `ref` matches a value and gives you a reference to it.
-
-The condition we want to check in the match guard is whether the value returned
-by `error.kind()` is the `NotFound` variant of the `ErrorKind` enum. If it is,
-we try to create the file with `File::create`. However, because `File::create`
-could also fail, we need to add an inner `match` expression as well. When the
-file can’t be opened, a different error message will be printed. The last arm
-of the outer `match` stays the same so the program panics on any error besides
-the missing file error.
-
-### Shortcuts for Panic on Error: `unwrap` and `expect`
-
-Using `match` works well enough, but it can be a bit verbose and doesn’t always
-communicate intent well. The `Result<T, E>` type has many helper methods
-defined on it to do various tasks. One of those methods, called `unwrap`, is a
-shortcut method that is implemented just like the `match` expression we wrote
-in Listing 9-4. If the `Result` value is the `Ok` variant, `unwrap` will return
-the value inside the `Ok`. If the `Result` is the `Err` variant, `unwrap` will
-call the `panic!` macro for us. Here is an example of `unwrap` in action:
-
-<span class="filename">Filename: src/main.rs</span>
->>>>>>> fork_master_master
 
 ```rust,should_panic
 use std::fs::File;

--- a/second-edition/src/ch17-01-what-is-oo.md
+++ b/second-edition/src/ch17-01-what-is-oo.md
@@ -263,68 +263,6 @@ Rustコードを共有でき、これは、リスト10-14で`Summary`トレイ�
 <!-- > sometimes called *bounded parametric polymorphism*. -->
 
 > ### 多相性
-=======
-<span class="caption">Listing 17-2: Implementations of the public methods
-`add`, `remove`, and `average` on `AveragedCollection`</span>
-
-The public methods `add`, `remove`, and `average` are the only ways to modify
-an instance of `AveragedCollection`. When an item is added to `list` using the
-`add` method or removed using the `remove` method, the implementations of each
-call the private `update_average` method that handles updating the `average`
-field as well.
-
-We leave the `list` and `average` fields private so there is no way for
-external code to add or remove items to the `list` field directly; otherwise,
-the `average` field might become out of sync when the `list` changes. The
-`average` method returns the value in the `average` field, allowing external
-code to read the `average` but not modify it.
-
-Because we’ve encapsulated the implementation details of the struct
-`AveragedCollection`, we can easily change aspects, such as the data structure,
-in the future. For instance, we could use a `HashSet<i32>` instead of a
-`Vec<i32>` for the `list` field. As long as the signatures of the `add`,
-`remove`, and `average` public methods stay the same, code using
-`AveragedCollection` wouldn’t need to change. If we made `list` public instead,
-this wouldn’t necessarily be the case: `HashSet<i32>` and `Vec<i32>` have
-different methods for adding and removing items, so the external code would
-likely have to change if it were modifying `list` directly.
-
-If encapsulation is a required aspect for a language to be considered object
-oriented, then Rust meets that requirement. The option to use `pub` or not for
-different parts of code enables encapsulation of implementation details.
-
-### Inheritance as a Type System and as Code Sharing
-
-*Inheritance* is a mechanism whereby an object can inherit from another
-object’s definition, thus gaining the parent object’s data and behavior without
-you having to define them again.
-
-If a language must have inheritance to be an object-oriented language, then
-Rust is not one. There is no way to define a struct that inherits the parent
-struct’s fields and method implementations. However, if you’re used to having
-inheritance in your programming toolbox, you can use other solutions in Rust,
-depending on your reason for reaching for inheritance in the first place.
-
-You choose inheritance for two main reasons. One is for reuse of code: you can
-implement particular behavior for one type, and inheritance enables you to
-reuse that implementation for a different type. You can share Rust code using
-default trait method implementations instead, which you saw in Listing 10-14
-when we added a default implementation of the `summarize` method on the
-`Summary` trait. Any type implementing the `Summary` trait would have the
-`summarize` method available on it without any further code. This is similar to
-a parent class having an implementation of a method and an inheriting child
-class also having the implementation of the method. We can also override the
-default implementation of the `summarize` method when we implement the
-`Summary` trait, which is similar to a child class overriding the
-implementation of a method inherited from a parent class.
-
-The other reason to use inheritance relates to the type system: to enable a
-child type to be used in the same places as the parent type. This is also
-called *polymorphism*, which means that you can substitute multiple objects for
-each other at runtime if they share certain characteristics.
-
-> ### Polymorphism
->>>>>>> fork_master_master
 >
 > 多くの人にとって、多相性は、継承の同義語です。ですが、実際には複数の型のデータを取り扱えるコードを指すより一般的な概念です。
 > 継承について言えば、それらの型は一般的にはサブクラスです。


### PR DESCRIPTION
## 概要

日本語の訳文のほうに不必要なマージの差分データが混入しており、作成した pdf の表示が崩れている状態でした。

<img width="1001" alt="broken-pdf-10" src="https://user-images.githubusercontent.com/1725620/41417750-307d5cfe-7029-11e8-95ff-6690cb5f4199.png">

<img width="997" alt="broken-pdf-19" src="https://user-images.githubusercontent.com/1725620/41417766-38c7f7b6-7029-11e8-9cf7-e3fa0e07dcb2.png">

この PR では不要なデータを削除して、pdf の表示が崩れないようにしました。

<img width="910" alt="after-fix-10" src="https://user-images.githubusercontent.com/1725620/41417822-612a3c6e-7029-11e8-83b8-ac9f80aa602a.png">

<img width="924" alt="after-fix-19" src="https://user-images.githubusercontent.com/1725620/41417836-67ac22f0-7029-11e8-8ba0-4b837f8c0fa9.png">
