### PR TITLE
Improve the translation of ch13-01-closures.md

### DIFF
--- a/second-edition/src/ch13-01-closures.md
+++ b/second-edition/src/ch13-01-closures.md
@@ -1094,7 +1094,7 @@ error[E0434]: can't capture dynamic environment in a fn item; use the || { ...
 <!-- * `FnMut` can change the environment because it mutably borrows values. -->
 <!-- * `Fn` borrows values from the environment immutably. -->
 
-* `FnOnce`は内包されたスコープからキャプチャした変数を消費し、これがクロージャの*環境*として知られています。
+* `FnOnce`は、クロージャの*環境*として知られている内包されたスコープからキャプチャした変数を消費します。
 キャプチャした変数を消費するために、定義された際にクロージャはこれらの変数の所有権を奪い、
 自身にムーブするのです。名前のうち、`Once`の部分は、
 このクロージャは同じ変数の所有権を2回以上奪うことができないという事実を表しているので、1回しか呼ぶことができないのです。


### PR DESCRIPTION
FnOnceの説明において，原文のknown as以下は，文全体ではなくits enclosing scopeを修飾している，すなわち「内包されたスコープ」がクロージャの環境として知られているという文なので，順序を変更して分かりやすくしました．